### PR TITLE
Listinstances only

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1399,6 +1399,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/golang/glog",
+    "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
     "github.com/spf13/cobra",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/kops/pkg/apis/kops",
@@ -1406,6 +1407,7 @@
     "k8s.io/kops/pkg/client/simple/vfsclientset",
     "k8s.io/kops/upup/pkg/fi",
     "k8s.io/kops/upup/pkg/fi/cloudup",
+    "k8s.io/kops/upup/pkg/fi/cloudup/openstack",
     "k8s.io/kops/util/pkg/reflectutils",
     "k8s.io/kops/util/pkg/vfs",
   ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1408,7 +1408,6 @@
     "k8s.io/kops/upup/pkg/fi",
     "k8s.io/kops/upup/pkg/fi/cloudup",
     "k8s.io/kops/upup/pkg/fi/cloudup/openstack",
-    "k8s.io/kops/util/pkg/reflectutils",
     "k8s.io/kops/util/pkg/vfs",
   ]
   solver-name = "gps-cdcl"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OPERATOR_NAME := kops-autoscaler-openstack
 IMAGE := elisaoyj/$(OPERATOR_NAME)
 
-.PHONY: copybindata bindata clean deps test gofmt ensure check build build-image build-linux-amd64
+.PHONY: copybindata bindata clean deps test gofmt ensure check build build-image build-linux-amd64 run
 
 copybindata:
 	cp ${GOPATH}/src/k8s.io/kops/upup/models/bindata.go replace/bindata.go
@@ -41,3 +41,6 @@ build: bindata
 
 build-image: build-linux-amd64
 	docker build -t $(IMAGE):latest .
+
+run: build
+	./bin/$(OPERATOR_NAME) --sleep 10

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -121,6 +121,7 @@ func (osASG *openstackASG) updateApplyCmd() error {
 
 // dryRun scans do we need run update or not
 // currently it supports scaling up and down instances
+// we do not use kops update cluster dryrun because it will make lots of API queries against OpenStack.
 func (osASG *openstackASG) dryRun() (bool, error) {
 	instances, err := osASG.Cloud.ListInstances(servers.ListOpts{})
 	if err != nil {

--- a/pkg/cmd/start.go
+++ b/pkg/cmd/start.go
@@ -59,7 +59,7 @@ func Execute() {
 
 func validate(options *autoscaler.Options) error {
 	if options.ClusterName == "" {
-		return fmt.Errorf("Please set NAME to env variable or as start flag")
+		return fmt.Errorf("Please set KOPS_CLUSTER_NAME to env variable or as start flag")
 	}
 	if options.StateStore == "" {
 		return fmt.Errorf("Please set KOPS_STATE_STORE to env variable or as start flag")


### PR DESCRIPTION
currently dryRun step is executed using `kops update cluster`. However, that will make lots of queries against openstack APIs. We are interested only of scaling instances up or down - so we do not need that much information.

