### PR TITLE
publish load balancer stats through prometheus endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Flags:
       --access-key string        S3 access key (default "test")
       --custom-endpoint string   S3 custom endpoint
   -h, --help                     help for kops-autoscaling-openstack
+      --load-balancer-metrics    collect load balancer metrics (default false)
       --name string              Name of the kubernetes kops cluster (default "")
       --secret-key string        S3 secret key (default "")
       --sleep int                Sleep between executions (default 45)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -310,11 +310,11 @@ func (osASG *openstackASG) getLoadBalancerMetrics() error {
 		}
 		glog.Infof("Load balancer statistics collected %s", lb.Name)
 
-		lbActiveConnections.WithLabelValues(lb.ID, lb.Name).Set(float64(stats.ActiveConnections))
-		lbBytesIn.WithLabelValues(lb.ID, lb.Name).Set(float64(stats.BytesIn))
-		lbBytesOut.WithLabelValues(lb.ID, lb.Name).Set(float64(stats.BytesOut))
-		lbRequestErros.WithLabelValues(lb.ID, lb.Name).Set(float64(stats.RequestErrors))
-		lbTotalConnections.WithLabelValues(lb.ID, lb.Name).Set(float64(stats.TotalConnections))
+		lbActiveConnections.WithLabelValues(lb.Name, lb.ID).Set(float64(stats.ActiveConnections))
+		lbBytesIn.WithLabelValues(lb.Name, lb.ID).Set(float64(stats.BytesIn))
+		lbBytesOut.WithLabelValues(lb.Name, lb.ID).Set(float64(stats.BytesOut))
+		lbRequestErros.WithLabelValues(lb.Name, lb.ID).Set(float64(stats.RequestErrors))
+		lbTotalConnections.WithLabelValues(lb.Name, lb.ID).Set(float64(stats.TotalConnections))
 	}
 
 	return nil

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -169,7 +169,7 @@ func Run(opts *Options) error {
 
 		// Collecting load balancer metrics is not critical. Don't want to fail on error.
 		if opts.LoadBalancerMetrics {
-			err = osASG.getLoadBalancerMetrics()
+			osASG.getLoadBalancerMetrics()
 		}
 
 		fails = 0

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
 
 	// import pprof package, needed for debugging
@@ -111,6 +112,12 @@ func Run(opts *Options) error {
 
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(":2112", nil)
+
+	prometheus.MustRegister(lbActiveConnections)
+	prometheus.MustRegister(lbBytesIn)
+	prometheus.MustRegister(lbBytesOut)
+	prometheus.MustRegister(lbRequestErros)
+	prometheus.MustRegister(lbTotalConnections)
 
 	fails := 0
 	for {
@@ -290,7 +297,7 @@ func (osASG *openstackASG) getLoadBalancerMetrics() error {
 		return err
 	}
 
-	glog.Infof("Found %s load balancers", len(allLoadBalancers))
+	glog.Infof("Found %s load balancers", strconv.Itoa(len(allLoadBalancers)))
 	if len(allLoadBalancers) == 0 {
 		return nil
 	}

--- a/pkg/cmd/start.go
+++ b/pkg/cmd/start.go
@@ -46,6 +46,7 @@ func Execute() {
 	}
 
 	rootCmd.Flags().IntVar(&options.Sleep, "sleep", 300, "Sleep between executions")
+	rootCmd.Flags().BoolVar(&options.LoadBalancerMetrics, "load-balancer-metrics", false, "Collect load balancer metrics")
 	rootCmd.Flags().StringVar(&options.StateStore, "state-store", os.Getenv("KOPS_STATE_STORE"), "KOPS State store")
 	rootCmd.Flags().StringVar(&options.AccessKey, "access-id", os.Getenv("S3_ACCESS_KEY_ID"), "S3 access key")
 	rootCmd.Flags().StringVar(&options.SecretKey, "secret-key", os.Getenv("S3_SECRET_ACCESS_KEY"), "S3 secret key")


### PR DESCRIPTION
Collect load balancer stats from OpenStack API and publish them through Prometheus endpoint.